### PR TITLE
Consistent naming and testing

### DIFF
--- a/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetPrivateTimeline/Endpoint.cs
+++ b/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetPrivateTimeline/Endpoint.cs
@@ -55,13 +55,13 @@ namespace MiniTwit.Api.Features.Timeline.GetPrivateTimeline
 
                     // Map Message entities to DTOs.
                     var dtos = messages
-                        .Select(m => new GetMessageDto
+                        .Select(m => new GetMessageResponse
                         {
                             MessageId = m.MessageId,
                             Text = m.Text,
                             PubDate = m.PubDate,
                             Author = m.Author is not null
-                                ? new GetUserDto
+                                ? new GetUserResponse
                                 {
                                     UserId = m.Author.UserId,
                                     Username = m.Author.Username,

--- a/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetPublicTimeline/Endpoint.cs
+++ b/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetPublicTimeline/Endpoint.cs
@@ -31,13 +31,13 @@ namespace MiniTwit.Api.Features.Timeline.GetPublicTimeline
                         .ToListAsync();
 
                     var dtos = messages
-                        .Select(m => new GetMessageDto
+                        .Select(m => new GetMessageResponse
                         {
                             MessageId = m.MessageId,
                             Text = m.Text,
                             PubDate = m.PubDate,
                             Author = m.Author is not null
-                                ? new GetUserDto
+                                ? new GetUserResponse
                                 {
                                     UserId = m.Author.UserId,
                                     Username = m.Author.Username,

--- a/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetUserTimeline/Endpoint.cs
+++ b/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetUserTimeline/Endpoint.cs
@@ -31,13 +31,13 @@ namespace MiniTwit.Api.Features.Timeline.GetUserTimeline
                         .ToListAsync();
 
                     var dtos = messages
-                        .Select(m => new GetMessageDto
+                        .Select(m => new GetMessageResponse
                         {
                             MessageId = m.MessageId,
                             Text = m.Text,
                             PubDate = m.PubDate,
                             Author = m.Author is not null
-                                ? new GetUserDto
+                                ? new GetUserResponse
                                 {
                                     UserId = m.Author.UserId,
                                     Username = m.Author.Username,

--- a/MiniTwitSolution/MiniTwit.Shared/DTO/Timeline/GetMessageResponse.cs
+++ b/MiniTwitSolution/MiniTwit.Shared/DTO/Timeline/GetMessageResponse.cs
@@ -1,9 +1,9 @@
 ﻿namespace MiniTwit.Shared.DTO.Timeline;
 
-public record GetMessageDto
+public record GetMessageResponse
 {
     public int MessageId { get; init; }
     public string Text { get; init; } = string.Empty;
     public int? PubDate { get; init; }
-    public GetUserDto? Author { get; init; }
+    public GetUserResponse? Author { get; init; }
 }

--- a/MiniTwitSolution/MiniTwit.Shared/DTO/Timeline/GetUserResponse.cs
+++ b/MiniTwitSolution/MiniTwit.Shared/DTO/Timeline/GetUserResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace MiniTwit.Shared.DTO.Timeline;
 
-public record GetUserDto
+public record GetUserResponse
 {
     public int UserId { get; init; }
     public string Username { get; init; } = string.Empty;

--- a/MiniTwitSolution/MiniTwit.Test/MiniTwitTests.cs
+++ b/MiniTwitSolution/MiniTwit.Test/MiniTwitTests.cs
@@ -38,7 +38,7 @@ public class MiniTwitTests : IAsyncLifetime
         _resetDatabase = factory.ResetDatabaseAsync;
         _miniTwitContext = factory.Services.GetRequiredService<MiniTwitDbContext>();
     }
-    
+
     [Fact]
     public async Task GetPrivateTimeLineWorksAsExpected()
     {
@@ -341,12 +341,11 @@ public class MiniTwitTests : IAsyncLifetime
     [Fact]
     public async Task LoginUserEndpoint_WorksAsExpected()
     {
-        
         var user = new User
         {
             Username = "loginuser",
             Email = "loginuser@example.com",
-            PwHash = "mypassword"
+            PwHash = "mypassword",
         };
         _miniTwitContext.Users.Add(user);
         await _miniTwitContext.SaveChangesAsync();


### PR DESCRIPTION
## Description 

Renamed all DTO's to have convention:
*Request if it is parameter for endpoint
*Response if it is returned by endpoint

This is reflected in the tests as well.

fixes
#17 

## Checklist

- [x] Formatted C# code using csharpier.
- [x] Added ```/Timespent Xh Ym``` in the last line of issue description.
- [x] Linked issue to this pull request by replacing "(issue)" with ```#issueNumber``` in description above.
