### PR TITLE
Hybrid cache

### DIFF
--- a/MiniTwitSolution/Documentation/MonitoringAndLogging.md
+++ b/MiniTwitSolution/Documentation/MonitoringAndLogging.md
@@ -1,0 +1,1 @@
+# Monitoring and logging

--- a/MiniTwitSolution/Documentation/Performance.md
+++ b/MiniTwitSolution/Documentation/Performance.md
@@ -3,5 +3,11 @@
 ## 12.02.2025
 
 ### Caching using HybridCache
+Guide used: https://www.youtube.com/watch?v=MQ96krIOjs4
+
+
+HybridCache unifies in-memory and distributed caching in one API, delivering both low latency and scalable reliability in a simpler, more efficient solution than older, fragmented approaches.
+
+
 
 

--- a/MiniTwitSolution/MiniTwit.Api/Features/Followers/FollowUser/Endpoint.cs
+++ b/MiniTwitSolution/MiniTwit.Api/Features/Followers/FollowUser/Endpoint.cs
@@ -12,11 +12,22 @@ namespace MiniTwit.Api.Features.Followers.FollowUser
             // POST /follow : Follow a user.
             routes.MapPost(
                 "/follow",
-                async (FollowRequest request, MiniTwitDbContext db, HybridCache hybridCache, CancellationToken cancellationToken) =>
+                async (
+                    FollowRequest request,
+                    MiniTwitDbContext db,
+                    HybridCache hybridCache,
+                    CancellationToken cancellationToken
+                ) =>
                 {
                     // Validate that both users exist.
-                    var follower = await db.Users.FindAsync(new object[] { request.FollowerId }, cancellationToken);
-                    var followed = await db.Users.FindAsync(new object[] { request.FollowedId }, cancellationToken);
+                    var follower = await db.Users.FindAsync(
+                        new object[] { request.FollowerId },
+                        cancellationToken
+                    );
+                    var followed = await db.Users.FindAsync(
+                        new object[] { request.FollowedId },
+                        cancellationToken
+                    );
                     if (follower == null || followed == null)
                     {
                         return Results.BadRequest("Invalid user IDs.");
@@ -43,7 +54,10 @@ namespace MiniTwit.Api.Features.Followers.FollowUser
                     await db.SaveChangesAsync(cancellationToken);
 
                     // Invalidate the follower’s private timeline (first page).
-                    await hybridCache.RemoveAsync($"privateTimeline:{request.FollowerId}:0", cancellationToken);
+                    await hybridCache.RemoveAsync(
+                        $"privateTimeline:{request.FollowerId}:0",
+                        cancellationToken
+                    );
 
                     // Return a simple DTO.
                     var dto = new FollowResponse(newFollower.WhoId, newFollower.WhomId);

--- a/MiniTwitSolution/MiniTwit.Api/Features/Followers/UnfollowUser/Endpoint.cs
+++ b/MiniTwitSolution/MiniTwit.Api/Features/Followers/UnfollowUser/Endpoint.cs
@@ -12,7 +12,12 @@ namespace MiniTwit.Api.Features.Followers.UnfollowUser
             // DELETE /follow : Unfollow a user.
             routes.MapDelete(
                 "/follow",
-                async (HttpRequest request, MiniTwitDbContext db, HybridCache hybridCache, CancellationToken cancellationToken) =>
+                async (
+                    HttpRequest request,
+                    MiniTwitDbContext db,
+                    HybridCache hybridCache,
+                    CancellationToken cancellationToken
+                ) =>
                 {
                     // Expect query parameters: followerId and followedId.
                     if (
@@ -37,7 +42,10 @@ namespace MiniTwit.Api.Features.Followers.UnfollowUser
                     await db.SaveChangesAsync(cancellationToken);
 
                     // Invalidate the follower’s private timeline (first page).
-                    await hybridCache.RemoveAsync($"privateTimeline:{followerId}:0", cancellationToken);
+                    await hybridCache.RemoveAsync(
+                        $"privateTimeline:{followerId}:0",
+                        cancellationToken
+                    );
 
                     // Return a DTO indicating success.
                     var dto = new UnfollowResponse(true, "Unfollowed successfully.");

--- a/MiniTwitSolution/MiniTwit.Api/Features/Followers/UnfollowUser/Endpoint.cs
+++ b/MiniTwitSolution/MiniTwit.Api/Features/Followers/UnfollowUser/Endpoint.cs
@@ -1,4 +1,5 @@
-﻿using MiniTwit.Shared.DTO.Followers.FollowUser;
+﻿using Microsoft.Extensions.Caching.Hybrid;
+using MiniTwit.Shared.DTO.Followers.FollowUser;
 
 namespace MiniTwit.Api.Features.Followers.UnfollowUser
 {
@@ -11,7 +12,7 @@ namespace MiniTwit.Api.Features.Followers.UnfollowUser
             // DELETE /follow : Unfollow a user.
             routes.MapDelete(
                 "/follow",
-                async (HttpRequest request, MiniTwitDbContext db) =>
+                async (HttpRequest request, MiniTwitDbContext db, HybridCache hybridCache, CancellationToken cancellationToken) =>
                 {
                     // Expect query parameters: followerId and followedId.
                     if (
@@ -23,8 +24,9 @@ namespace MiniTwit.Api.Features.Followers.UnfollowUser
                     }
 
                     // Locate the follow relationship.
-                    var followRecord = await db.Followers.FirstOrDefaultAsync(f =>
-                        f.WhoId == followerId && f.WhomId == followedId
+                    var followRecord = await db.Followers.FirstOrDefaultAsync(
+                        f => f.WhoId == followerId && f.WhomId == followedId,
+                        cancellationToken
                     );
                     if (followRecord == null)
                     {
@@ -32,14 +34,16 @@ namespace MiniTwit.Api.Features.Followers.UnfollowUser
                     }
 
                     db.Followers.Remove(followRecord);
-                    await db.SaveChangesAsync();
+                    await db.SaveChangesAsync(cancellationToken);
+
+                    // Invalidate the follower’s private timeline (first page).
+                    await hybridCache.RemoveAsync($"privateTimeline:{followerId}:0", cancellationToken);
 
                     // Return a DTO indicating success.
                     var dto = new UnfollowResponse(true, "Unfollowed successfully.");
                     return Results.Ok(dto);
                 }
             );
-
             return routes;
         }
     }

--- a/MiniTwitSolution/MiniTwit.Api/Features/Messages/PostMessage/Endpoint.cs
+++ b/MiniTwitSolution/MiniTwit.Api/Features/Messages/PostMessage/Endpoint.cs
@@ -9,11 +9,18 @@ public static class Endpoint
     {
         routes.MapPost(
             "/add_message",
-            async (PostMessageRequest request, MiniTwitDbContext db, HybridCache hybridCache,
-                CancellationToken cancellationToken) =>
+            async (
+                PostMessageRequest request,
+                MiniTwitDbContext db,
+                HybridCache hybridCache,
+                CancellationToken cancellationToken
+            ) =>
             {
                 // Validate that the author exists.
-                var author = await db.Users.FindAsync(new object[] { request.AuthorId }, cancellationToken);
+                var author = await db.Users.FindAsync(
+                    new object[] { request.AuthorId },
+                    cancellationToken
+                );
                 if (author == null)
                 {
                     return Results.BadRequest("Author not found.");
@@ -38,15 +45,21 @@ public static class Endpoint
                 // - Public timeline (first page)
                 await hybridCache.RemoveAsync("publicTimeline:0", cancellationToken);
                 // - Author's own timeline (first page)
-                await hybridCache.RemoveAsync($"userTimeline:{request.AuthorId}:0", cancellationToken);
+                await hybridCache.RemoveAsync(
+                    $"userTimeline:{request.AuthorId}:0",
+                    cancellationToken
+                );
                 // - Private timelines of all followers of the author (first page)
-                var followerIds = await db.Followers
-                    .Where(f => f.WhomId == request.AuthorId)
+                var followerIds = await db
+                    .Followers.Where(f => f.WhomId == request.AuthorId)
                     .Select(f => f.WhoId)
                     .ToListAsync(cancellationToken);
                 foreach (var followerId in followerIds)
                 {
-                    await hybridCache.RemoveAsync($"privateTimeline:{followerId}:0", cancellationToken);
+                    await hybridCache.RemoveAsync(
+                        $"privateTimeline:{followerId}:0",
+                        cancellationToken
+                    );
                 }
 
                 // Build the response DTO.

--- a/MiniTwitSolution/MiniTwit.Api/Features/Messages/PostMessage/Endpoint.cs
+++ b/MiniTwitSolution/MiniTwit.Api/Features/Messages/PostMessage/Endpoint.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Caching.Hybrid;
 using MiniTwit.Shared.DTO.Messages;
 
 namespace MiniTwit.Api.Features.Messages.PostMessage;
@@ -8,10 +9,11 @@ public static class Endpoint
     {
         routes.MapPost(
             "/add_message",
-            async (PostMessageRequest request, MiniTwitDbContext db) =>
+            async (PostMessageRequest request, MiniTwitDbContext db, HybridCache hybridCache,
+                CancellationToken cancellationToken) =>
             {
                 // Validate that the author exists.
-                var author = await db.Users.FindAsync(request.AuthorId);
+                var author = await db.Users.FindAsync(new object[] { request.AuthorId }, cancellationToken);
                 if (author == null)
                 {
                     return Results.BadRequest("Author not found.");
@@ -30,7 +32,22 @@ public static class Endpoint
                 };
 
                 db.Messages.Add(message);
-                await db.SaveChangesAsync();
+                await db.SaveChangesAsync(cancellationToken);
+
+                // Invalidate caches impacted by a new message:
+                // - Public timeline (first page)
+                await hybridCache.RemoveAsync("publicTimeline:0", cancellationToken);
+                // - Author's own timeline (first page)
+                await hybridCache.RemoveAsync($"userTimeline:{request.AuthorId}:0", cancellationToken);
+                // - Private timelines of all followers of the author (first page)
+                var followerIds = await db.Followers
+                    .Where(f => f.WhomId == request.AuthorId)
+                    .Select(f => f.WhoId)
+                    .ToListAsync(cancellationToken);
+                foreach (var followerId in followerIds)
+                {
+                    await hybridCache.RemoveAsync($"privateTimeline:{followerId}:0", cancellationToken);
+                }
 
                 // Build the response DTO.
                 var responseDto = new PostMessageResponse(

--- a/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetPrivateTimeline/Endpoint.cs
+++ b/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetPrivateTimeline/Endpoint.cs
@@ -1,16 +1,24 @@
-using MiniTwit.Shared.DTO.Timeline;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Hybrid;
+using MiniTwit.Shared.DTO.Timeline;
 
 namespace MiniTwit.Api.Features.Timeline.GetPrivateTimeline
 {
     public static class Endpoint
     {
-        public static IEndpointRouteBuilder MapGetPrivateTimelineEndpoints(this IEndpointRouteBuilder routes)
+        public static IEndpointRouteBuilder MapGetPrivateTimelineEndpoints(
+            this IEndpointRouteBuilder routes
+        )
         {
             routes.MapGet(
                 "/",
-                async (HttpContext context, int? offset, MiniTwitDbContext db, HybridCache hybridCache, CancellationToken cancellationToken) =>
+                async (
+                    HttpContext context,
+                    int? offset,
+                    MiniTwitDbContext db,
+                    HybridCache hybridCache,
+                    CancellationToken cancellationToken
+                ) =>
                 {
                     // Require the "userId" query parameter.
                     if (!context.Request.Query.ContainsKey("userId"))
@@ -31,31 +39,37 @@ namespace MiniTwit.Api.Features.Timeline.GetPrivateTimeline
                         async ct =>
                         {
                             // Get the list of users the current user follows.
-                            var followedUserIds = await db.Followers
-                                .Where(f => f.WhoId == userId)
+                            var followedUserIds = await db
+                                .Followers.Where(f => f.WhoId == userId)
                                 .Select(f => f.WhomId)
                                 .ToListAsync(ct);
                             followedUserIds.Add(userId); // Include self
 
-                            var messages = await db.Messages
-                                .Where(m => (m.Flagged ?? 0) == 0 && followedUserIds.Contains(m.AuthorId))
+                            var messages = await db
+                                .Messages.Where(m =>
+                                    (m.Flagged ?? 0) == 0 && followedUserIds.Contains(m.AuthorId)
+                                )
                                 .OrderByDescending(m => m.PubDate)
                                 .Skip(skip)
                                 .Take(perPage)
                                 .Include(m => m.Author)
                                 .ToListAsync(ct);
 
-                            return messages.Select(m => new GetMessageResponse
-                            {
-                                MessageId = m.MessageId,
-                                Text = m.Text,
-                                PubDate = m.PubDate,
-                                Author = m.Author is not null ? new GetUserResponse
+                            return messages
+                                .Select(m => new GetMessageResponse
                                 {
-                                    UserId = m.Author.UserId,
-                                    Username = m.Author.Username,
-                                } : null,
-                            }).ToList();
+                                    MessageId = m.MessageId,
+                                    Text = m.Text,
+                                    PubDate = m.PubDate,
+                                    Author = m.Author is not null
+                                        ? new GetUserResponse
+                                        {
+                                            UserId = m.Author.UserId,
+                                            Username = m.Author.Username,
+                                        }
+                                        : null,
+                                })
+                                .ToList();
                         },
                         cancellationToken: cancellationToken
                     );

--- a/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetPrivateTimeline/Endpoint.cs
+++ b/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetPrivateTimeline/Endpoint.cs
@@ -1,30 +1,22 @@
-using System.Linq.Expressions;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-using Microsoft.EntityFrameworkCore;
-using MiniTwit.Api.Domain;
-using MiniTwit.Api.Features.Timeline;
-using MiniTwit.Api.Infrastructure;
 using MiniTwit.Shared.DTO.Timeline;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Hybrid;
 
 namespace MiniTwit.Api.Features.Timeline.GetPrivateTimeline
 {
     public static class Endpoint
     {
-        public static IEndpointRouteBuilder MapGetPrivateTimelineEndpoints(
-            this IEndpointRouteBuilder routes
-        )
+        public static IEndpointRouteBuilder MapGetPrivateTimelineEndpoints(this IEndpointRouteBuilder routes)
         {
             routes.MapGet(
                 "/",
-                async (HttpContext context, int? offset, MiniTwitDbContext db) =>
+                async (HttpContext context, int? offset, MiniTwitDbContext db, HybridCache hybridCache, CancellationToken cancellationToken) =>
                 {
-                    // Check for "userId" query parameter to simulate logged-in user.
+                    // Require the "userId" query parameter.
                     if (!context.Request.Query.ContainsKey("userId"))
                     {
                         return Results.Redirect("/public");
                     }
-
                     if (!int.TryParse(context.Request.Query["userId"], out int userId))
                     {
                         return Results.BadRequest("Invalid userId");
@@ -32,43 +24,41 @@ namespace MiniTwit.Api.Features.Timeline.GetPrivateTimeline
 
                     const int perPage = 30;
                     int skip = offset ?? 0;
+                    string cacheKey = $"privateTimeline:{userId}:{skip}";
 
-                    // Get the list of followed user IDs
-                    var followedUserIds = await db
-                        .Followers.Where(f => f.WhoId == userId)
-                        .Select(f => f.WhomId)
-                        .ToListAsync();
-
-                    // Include the current user's own ID.
-                    followedUserIds.Add(userId);
-
-                    // Query messages with the filter.
-                    var messages = await db
-                        .Messages.Where(m =>
-                            (m.Flagged ?? 0) == 0 && followedUserIds.Contains(m.AuthorId)
-                        )
-                        .OrderByDescending(m => m.PubDate)
-                        .Skip(skip)
-                        .Take(perPage)
-                        .Include(m => m.Author)
-                        .ToListAsync();
-
-                    // Map Message entities to DTOs.
-                    var dtos = messages
-                        .Select(m => new GetMessageResponse
+                    var dtos = await hybridCache.GetOrCreateAsync<List<GetMessageResponse>>(
+                        cacheKey,
+                        async ct =>
                         {
-                            MessageId = m.MessageId,
-                            Text = m.Text,
-                            PubDate = m.PubDate,
-                            Author = m.Author is not null
-                                ? new GetUserResponse
+                            // Get the list of users the current user follows.
+                            var followedUserIds = await db.Followers
+                                .Where(f => f.WhoId == userId)
+                                .Select(f => f.WhomId)
+                                .ToListAsync(ct);
+                            followedUserIds.Add(userId); // Include self
+
+                            var messages = await db.Messages
+                                .Where(m => (m.Flagged ?? 0) == 0 && followedUserIds.Contains(m.AuthorId))
+                                .OrderByDescending(m => m.PubDate)
+                                .Skip(skip)
+                                .Take(perPage)
+                                .Include(m => m.Author)
+                                .ToListAsync(ct);
+
+                            return messages.Select(m => new GetMessageResponse
+                            {
+                                MessageId = m.MessageId,
+                                Text = m.Text,
+                                PubDate = m.PubDate,
+                                Author = m.Author is not null ? new GetUserResponse
                                 {
                                     UserId = m.Author.UserId,
                                     Username = m.Author.Username,
-                                }
-                                : null,
-                        })
-                        .ToList();
+                                } : null,
+                            }).ToList();
+                        },
+                        cancellationToken: cancellationToken
+                    );
 
                     return Results.Ok(dtos);
                 }

--- a/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetPublicTimeline/Endpoint.cs
+++ b/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetPublicTimeline/Endpoint.cs
@@ -1,62 +1,56 @@
-using Microsoft.Extensions.Caching.Hybrid;
 using MiniTwit.Shared.DTO.Timeline;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Hybrid;
 
-namespace MiniTwit.Api.Features.Timeline.GetPublicTimeline;
-
-public static class Endpoint
+namespace MiniTwit.Api.Features.Timeline.GetPublicTimeline
 {
-    public static IEndpointRouteBuilder MapGetPublicTimelineEndpoints(
-        this IEndpointRouteBuilder routes
-    )
+    public static class Endpoint
     {
-        routes.MapGet(
-            "/public",
-            async (
-                HttpContext context, 
-                int? offset, 
-                MiniTwitDbContext db, 
-                HybridCache hybridCache,
-                CancellationToken cancellationToken) =>
-            {
-                const int perPage = 30;
-                int skip = offset ?? 0;
+        public static IEndpointRouteBuilder MapGetPublicTimelineEndpoints(this IEndpointRouteBuilder routes)
+        {
+            routes.MapGet(
+                "/public",
+                async (HttpContext context, int? offset, MiniTwitDbContext db, HybridCache hybridCache, CancellationToken cancellationToken) =>
+                {
+                    const int perPage = 30;
+                    int skip = offset ?? 0;
+                    
+                    // Construct a unique cache key.
+                    string cacheKey = $"publicTimeline:{skip}";
 
-                // Build a cache key based on the offset.
-                string cacheKey = $"publicTimeline:{skip}";
-
-                // Use GetOrCreateAsync to either get the cached result or execute the factory.
-                var dtos = await hybridCache.GetOrCreateAsync<List<GetMessageResponse>>(
-                    cacheKey,
-                    async ct =>
-                    {
-                        // Query the database (pass the cancellation token to EF Core)
-                        var messages = await db.Messages
-                            .Where(m => (m.Flagged ?? 0) == 0)
-                            .OrderByDescending(m => m.PubDate)
-                            .Skip(skip)
-                            .Take(perPage)
-                            .Include(m => m.Author)
-                            .ToListAsync(ct);
-
-                        // Map entities to DTOs.
-                        return messages.Select(m => new GetMessageResponse
+                    // Retrieve from cache or execute the factory delegate.
+                    var dtos = await hybridCache.GetOrCreateAsync<List<GetMessageResponse>>(
+                        cacheKey,
+                        async ct =>
                         {
-                            MessageId = m.MessageId,
-                            Text = m.Text,
-                            PubDate = m.PubDate,
-                            Author = m.Author is not null
-                                ? new GetUserResponse
+                            var messages = await db.Messages
+                                .Where(m => (m.Flagged ?? 0) == 0)
+                                .OrderByDescending(m => m.PubDate)
+                                .Skip(skip)
+                                .Take(perPage)
+                                .Include(m => m.Author)
+                                .ToListAsync(ct);
+
+                            return messages.Select(m => new GetMessageResponse
+                            {
+                                MessageId = m.MessageId,
+                                Text = m.Text,
+                                PubDate = m.PubDate,
+                                Author = m.Author is not null ? new GetUserResponse
                                 {
                                     UserId = m.Author.UserId,
                                     Username = m.Author.Username,
-                                }
-                                : null,
-                        }).ToList();
-                    }, cancellationToken: cancellationToken);
+                                } : null,
+                            }).ToList();
+                        },
+                        cancellationToken: cancellationToken
+                    );
 
-                return Results.Ok(dtos);
-            }
-        );
-        return routes;
+                    return Results.Ok(dtos);
+                }
+            );
+
+            return routes;
+        }
     }
 }

--- a/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetPublicTimeline/Endpoint.cs
+++ b/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetPublicTimeline/Endpoint.cs
@@ -1,20 +1,28 @@
-using MiniTwit.Shared.DTO.Timeline;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Hybrid;
+using MiniTwit.Shared.DTO.Timeline;
 
 namespace MiniTwit.Api.Features.Timeline.GetPublicTimeline
 {
     public static class Endpoint
     {
-        public static IEndpointRouteBuilder MapGetPublicTimelineEndpoints(this IEndpointRouteBuilder routes)
+        public static IEndpointRouteBuilder MapGetPublicTimelineEndpoints(
+            this IEndpointRouteBuilder routes
+        )
         {
             routes.MapGet(
                 "/public",
-                async (HttpContext context, int? offset, MiniTwitDbContext db, HybridCache hybridCache, CancellationToken cancellationToken) =>
+                async (
+                    HttpContext context,
+                    int? offset,
+                    MiniTwitDbContext db,
+                    HybridCache hybridCache,
+                    CancellationToken cancellationToken
+                ) =>
                 {
                     const int perPage = 30;
                     int skip = offset ?? 0;
-                    
+
                     // Construct a unique cache key.
                     string cacheKey = $"publicTimeline:{skip}";
 
@@ -23,25 +31,29 @@ namespace MiniTwit.Api.Features.Timeline.GetPublicTimeline
                         cacheKey,
                         async ct =>
                         {
-                            var messages = await db.Messages
-                                .Where(m => (m.Flagged ?? 0) == 0)
+                            var messages = await db
+                                .Messages.Where(m => (m.Flagged ?? 0) == 0)
                                 .OrderByDescending(m => m.PubDate)
                                 .Skip(skip)
                                 .Take(perPage)
                                 .Include(m => m.Author)
                                 .ToListAsync(ct);
 
-                            return messages.Select(m => new GetMessageResponse
-                            {
-                                MessageId = m.MessageId,
-                                Text = m.Text,
-                                PubDate = m.PubDate,
-                                Author = m.Author is not null ? new GetUserResponse
+                            return messages
+                                .Select(m => new GetMessageResponse
                                 {
-                                    UserId = m.Author.UserId,
-                                    Username = m.Author.Username,
-                                } : null,
-                            }).ToList();
+                                    MessageId = m.MessageId,
+                                    Text = m.Text,
+                                    PubDate = m.PubDate,
+                                    Author = m.Author is not null
+                                        ? new GetUserResponse
+                                        {
+                                            UserId = m.Author.UserId,
+                                            Username = m.Author.Username,
+                                        }
+                                        : null,
+                                })
+                                .ToList();
                         },
                         cancellationToken: cancellationToken
                     );

--- a/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetPublicTimeline/Endpoint.cs
+++ b/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetPublicTimeline/Endpoint.cs
@@ -1,37 +1,45 @@
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-using Microsoft.EntityFrameworkCore;
-using MiniTwit.Api.Domain;
-using MiniTwit.Api.Features.Timeline;
-using MiniTwit.Api.Infrastructure;
+using Microsoft.Extensions.Caching.Hybrid;
 using MiniTwit.Shared.DTO.Timeline;
 
-namespace MiniTwit.Api.Features.Timeline.GetPublicTimeline
+namespace MiniTwit.Api.Features.Timeline.GetPublicTimeline;
+
+public static class Endpoint
 {
-    public static class Endpoint
+    public static IEndpointRouteBuilder MapGetPublicTimelineEndpoints(
+        this IEndpointRouteBuilder routes
+    )
     {
-        public static IEndpointRouteBuilder MapGetPublicTimelineEndpoints(
-            this IEndpointRouteBuilder routes
-        )
-        {
-            routes.MapGet(
-                "/public",
-                async (HttpContext context, int? offset, MiniTwitDbContext db) =>
-                {
-                    const int perPage = 30;
-                    int skip = offset ?? 0;
+        routes.MapGet(
+            "/public",
+            async (
+                HttpContext context, 
+                int? offset, 
+                MiniTwitDbContext db, 
+                HybridCache hybridCache,
+                CancellationToken cancellationToken) =>
+            {
+                const int perPage = 30;
+                int skip = offset ?? 0;
 
-                    // For the public timeline, return all messages that are not flagged.
-                    var messages = await db
-                        .Messages.Where(m => (m.Flagged ?? 0) == 0)
-                        .OrderByDescending(m => m.PubDate)
-                        .Skip(skip)
-                        .Take(perPage)
-                        .Include(m => m.Author)
-                        .ToListAsync();
+                // Build a cache key based on the offset.
+                string cacheKey = $"publicTimeline:{skip}";
 
-                    var dtos = messages
-                        .Select(m => new GetMessageResponse
+                // Use GetOrCreateAsync to either get the cached result or execute the factory.
+                var dtos = await hybridCache.GetOrCreateAsync<List<GetMessageResponse>>(
+                    cacheKey,
+                    async ct =>
+                    {
+                        // Query the database (pass the cancellation token to EF Core)
+                        var messages = await db.Messages
+                            .Where(m => (m.Flagged ?? 0) == 0)
+                            .OrderByDescending(m => m.PubDate)
+                            .Skip(skip)
+                            .Take(perPage)
+                            .Include(m => m.Author)
+                            .ToListAsync(ct);
+
+                        // Map entities to DTOs.
+                        return messages.Select(m => new GetMessageResponse
                         {
                             MessageId = m.MessageId,
                             Text = m.Text,
@@ -43,14 +51,12 @@ namespace MiniTwit.Api.Features.Timeline.GetPublicTimeline
                                     Username = m.Author.Username,
                                 }
                                 : null,
-                        })
-                        .ToList();
+                        }).ToList();
+                    }, cancellationToken: cancellationToken);
 
-                    return Results.Ok(dtos);
-                }
-            );
-
-            return routes;
-        }
+                return Results.Ok(dtos);
+            }
+        );
+        return routes;
     }
 }

--- a/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetUserTimeline/Endpoint.cs
+++ b/MiniTwitSolution/MiniTwit.Api/Features/Timeline/GetUserTimeline/Endpoint.cs
@@ -1,50 +1,47 @@
-using Microsoft.AspNetCore.Builder;
-using Microsoft.EntityFrameworkCore;
-using MiniTwit.Api.Domain;
-using MiniTwit.Api.Features.Timeline;
-using MiniTwit.Api.Infrastructure;
 using MiniTwit.Shared.DTO.Timeline;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Hybrid;
 
 namespace MiniTwit.Api.Features.Timeline.GetUserTimeline
 {
     public static class Endpoint
     {
-        public static IEndpointRouteBuilder MapGetUserTimelineEndpoints(
-            this IEndpointRouteBuilder routes
-        )
+        public static IEndpointRouteBuilder MapGetUserTimelineEndpoints(this IEndpointRouteBuilder routes)
         {
-            // This endpoint expects a user ID in the URL, e.g. /user/1
             routes.MapGet(
                 "/user/{id:int}",
-                async (int id, int? offset, MiniTwitDbContext db) =>
+                async (int id, int? offset, MiniTwitDbContext db, HybridCache hybridCache, CancellationToken cancellationToken) =>
                 {
                     const int perPage = 30;
                     int skip = offset ?? 0;
+                    string cacheKey = $"userTimeline:{id}:{skip}";
 
-                    // Return messages authored by the specified user that are not flagged.
-                    var messages = await db
-                        .Messages.Where(m => m.AuthorId == id && (m.Flagged ?? 0) == 0)
-                        .OrderByDescending(m => m.PubDate)
-                        .Skip(skip)
-                        .Take(perPage)
-                        .Include(m => m.Author)
-                        .ToListAsync();
-
-                    var dtos = messages
-                        .Select(m => new GetMessageResponse
+                    var dtos = await hybridCache.GetOrCreateAsync<List<GetMessageResponse>>(
+                        cacheKey,
+                        async ct =>
                         {
-                            MessageId = m.MessageId,
-                            Text = m.Text,
-                            PubDate = m.PubDate,
-                            Author = m.Author is not null
-                                ? new GetUserResponse
+                            var messages = await db.Messages
+                                .Where(m => m.AuthorId == id && (m.Flagged ?? 0) == 0)
+                                .OrderByDescending(m => m.PubDate)
+                                .Skip(skip)
+                                .Take(perPage)
+                                .Include(m => m.Author)
+                                .ToListAsync(ct);
+
+                            return messages.Select(m => new GetMessageResponse
+                            {
+                                MessageId = m.MessageId,
+                                Text = m.Text,
+                                PubDate = m.PubDate,
+                                Author = m.Author is not null ? new GetUserResponse
                                 {
                                     UserId = m.Author.UserId,
                                     Username = m.Author.Username,
-                                }
-                                : null,
-                        })
-                        .ToList();
+                                } : null,
+                            }).ToList();
+                        },
+                        cancellationToken: cancellationToken
+                    );
 
                     return Results.Ok(dtos);
                 }

--- a/MiniTwitSolution/MiniTwit.Api/MiniTwit.Api.csproj
+++ b/MiniTwitSolution/MiniTwit.Api/MiniTwit.Api.csproj
@@ -12,6 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="9.2.0-preview.1.25105.6" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>

--- a/MiniTwitSolution/MiniTwit.Api/Program.cs
+++ b/MiniTwitSolution/MiniTwit.Api/Program.cs
@@ -42,7 +42,7 @@ builder.Services.AddHybridCache(options =>
     options.DefaultEntryOptions = new HybridCacheEntryOptions()
     {
         LocalCacheExpiration = TimeSpan.FromMinutes(5),
-        Expiration = TimeSpan.FromMinutes(5)
+        Expiration = TimeSpan.FromMinutes(5),
     };
 });
 #pragma warning restore EXTEXP0018

--- a/MiniTwitSolution/MiniTwit.Api/Program.cs
+++ b/MiniTwitSolution/MiniTwit.Api/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Caching.Hybrid;
 using MiniTwit.Api.Features.Followers.FollowUser;
 using MiniTwit.Api.Features.Followers.UnfollowUser;
 using MiniTwit.Api.Features.Messages.PostMessage;
@@ -30,6 +31,22 @@ if (!builder.Environment.IsEnvironment("Testing"))
         provider.GetRequiredService<MiniTwitDbContext>()
     );
 }
+
+// Register basic caching services
+builder.Services.AddMemoryCache();
+
+// Register HybridCache (using the new .NET 9 API or a preview package)
+#pragma warning disable EXTEXP0018
+builder.Services.AddHybridCache(options =>
+{
+    options.DefaultEntryOptions = new HybridCacheEntryOptions()
+    {
+        LocalCacheExpiration = TimeSpan.FromMinutes(5),
+        Expiration = TimeSpan.FromMinutes(5)
+    };
+});
+#pragma warning restore EXTEXP0018
+
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Description 

We are using the new Hybrid Cache from .net, that combines MemoryCache and DistributedCache in one.
In short:
For GET endpoints: We use cache.GetOrCreate(...)
For POST/Delete endpoints We invalidate the relevant cache, so next GET will get fresh data.

fixes
#24 

## Checklist

- [x] Formatted C# code using csharpier.
- [x] Added ```/Timespent Xh Ym``` in the last line of issue description.
- [x] Linked issue to this pull request by replacing "(issue)" with ```#issueNumber``` in description above.
